### PR TITLE
Add audit pre-commit hooks

### DIFF
--- a/browser extension/plugin/.husky/pre-commit
+++ b/browser extension/plugin/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+cd "browser extension/plugin"
+npm run pre-commit

--- a/browser extension/plugin/.npmrc
+++ b/browser extension/plugin/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/browser extension/plugin/package-lock.json
+++ b/browser extension/plugin/package-lock.json
@@ -24,7 +24,12 @@
         "styled-components": "^5.3.3"
       },
       "devDependencies": {
+        "husky": "^7.0.4",
         "parcel": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3342,9 +3347,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -3795,6 +3800,21 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/i18next": {
       "version": "21.6.9",
@@ -9261,9 +9281,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -9568,6 +9588,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     },
     "i18next": {

--- a/browser extension/plugin/package.json
+++ b/browser extension/plugin/package.json
@@ -3,16 +3,19 @@
   "version": "0.0.1",
   "description": "",
   "scripts": {
+    "prepare": "cd ../.. && husky install \"browser extension/plugin/.husky\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:options": "parcel html/options.html",
     "start:popup": "parcel html/popup.html",
     "start:contentScript": "parcel html/content.html",
-    "build": "parcel build html/*.html react/*.jsx"
+    "build": "parcel build html/*.html react/*.jsx",
+    "pre-commit": "npm audit --audit-level=moderate"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "husky": "^7.0.4",
     "parcel": "^2.2.1"
   },
   "dependencies": {
@@ -29,5 +32,9 @@
     "react-i18next": "^11.15.3",
     "react-router-dom": "^6.2.1",
     "styled-components": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=16.14.0",
+    "npm": ">=8.3.1"
   }
 }


### PR DESCRIPTION
Fixes #46 
- Added husky as dev dependency
- Added husky prepare script
- Added node and npm engine versions with engine-strict enforcement
- Added pre-commit hooks for audit with failure at moderate audit level