### PR TITLE
Firefox support + A few bugfixes

### DIFF
--- a/browser extension/plugin/manifest.firefox.json
+++ b/browser extension/plugin/manifest.firefox.json
@@ -1,0 +1,38 @@
+{
+    "update_url": "https://clients2.google.com/service/update2/crx",
+    "manifest_version": 2,
+    "name": "uli",
+    "description": "Moderate your Twitter Feed",
+    "version": "0.1.2",
+    "author": "tattlemade|cis",
+    "permissions": [
+        "storage",
+        "https://twitter.com/*",
+        "https://ogbv-plugin.tattle.co.in/",
+        "https://s3.ap-south-1.amazonaws.com/ogbv-plugin.tattle.co.in/*",
+        "http://uli.tattle.co.in/*",
+        "https://*.twimg.com/*"
+    ],
+    "background": {
+        "scripts": ["background.js"]
+    },
+    "content_scripts": [
+        {
+            "matches": ["https://twitter.com/*"],
+            "js": ["content-script.js"],
+            "run_at": "document_end"
+        }
+    ],
+    "page_action": {
+        "default_icon": {
+            "19": "icon16.png",
+            "38": "icon32.png"
+        },
+        "default_popup": "options.html",
+        "show_matches": ["https://*.twitter.com/*"]
+    },
+    "icons": {
+        "16": "icon16.png",
+        "48": "icon32.png"
+    }
+}

--- a/browser extension/plugin/src/content-script.js
+++ b/browser extension/plugin/src/content-script.js
@@ -50,6 +50,11 @@ chrome.runtime.onMessage.addListener(function (request) {
 chrome.runtime.onMessage.addListener(async function (message) {
     if (message.type === 'updateData') {
         console.log('data changed. time to update slurs');
+        // Remove all earlier grommets first
+        let old = document.getElementsByClassName('ogbv-tweetcontrol-bar');
+        Array.prototype.forEach(old, (el) => {
+            el.remove();
+        });
         const preference = await getPreferenceData();
         console.log(preference);
         if (preference.slurList != undefined) {

--- a/browser extension/plugin/src/content-script.js
+++ b/browser extension/plugin/src/content-script.js
@@ -50,11 +50,6 @@ chrome.runtime.onMessage.addListener(function (request) {
 chrome.runtime.onMessage.addListener(async function (message) {
     if (message.type === 'updateData') {
         console.log('data changed. time to update slurs');
-        // Remove all earlier grommets first
-        let old = document.getElementsByClassName('ogbv-tweetcontrol-bar');
-        Array.prototype.forEach(old, (el) => {
-            el.remove();
-        });
         const preference = await getPreferenceData();
         console.log(preference);
         if (preference.slurList != undefined) {

--- a/browser extension/plugin/src/service-screenshot.js
+++ b/browser extension/plugin/src/service-screenshot.js
@@ -6,7 +6,11 @@ const { uploadArchivedMedia } = Api;
 export function saveScreenshot(element, storeLocally, accessToken, tweetUrl) {
     try {
         return domtoimage
-            .toBlob(element.lastChild, { bgcolor: 'white' })
+            .toBlob(element.lastChild, {
+                bgcolor: window
+                    .getComputedStyle(document.body, null)
+                    .getPropertyValue('background-color')
+            })
             .then(async function (blob) {
                 let fileName;
                 const url = location.href;

--- a/browser extension/plugin/src/transform.js
+++ b/browser extension/plugin/src/transform.js
@@ -62,7 +62,10 @@ const processNewlyAddedNodes = function (addedNodes) {
             tweet.innerText = replaceSlur(text);
         }
 
-        if (tweet.spans.length > 0) {
+        if (
+            tweet.spans.length > 0 &&
+            node.getElementsByClassName('ogbv-tweetcontrol-bar').length == 0
+        ) {
             addInlineMenu(id, node);
         }
     });

--- a/browser extension/plugin/src/twitter/tweet-controls.jsx
+++ b/browser extension/plugin/src/twitter/tweet-controls.jsx
@@ -139,7 +139,7 @@ export function TweetControl({ tweet, id, setBlur }) {
     }
 
     return (
-        <Grommet theme={Theme}>
+        <Grommet className="ogbv-tweetcontrol-bar" theme={Theme}>
             <Box direction="row" background={'white'}>
                 <Box flex="grow"></Box>
                 {!collapsed ? (


### PR DESCRIPTION
## Firefox Support
Added `manifest.firefox.yaml` which works on firefox.

### Testing Instructions
```
cp manifest.firefox.yaml manifest.yaml
npm run build
```
Now test the newly built add on from the dist folder in firefox developer edition as mentioned [here](https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/). You can load the manifest.yaml from the dist folder as a temporary add on.

## Publishing the extension

https://extensionworkshop.com/documentation/publish/ - Haven't explored this yet. I guess it's better if some core member of tattle does this :)

## Other bugfixes:
1. When the twitter background is dark, the screenshot had white text on white background. Updated to set the backgound as per the twitter background.
2. The inline controls would show up multiple times. I could replicate this on firefox all the time, and sometimes on chrome. 