### PR TITLE
fix: refresh does not change background color. Resolves #167

### DIFF
--- a/uli-website/src/components/molecules/AppShell.jsx
+++ b/uli-website/src/components/molecules/AppShell.jsx
@@ -20,7 +20,7 @@ export default function AppShell({ children }) {
         <Helmet>
           <meta charSet="utf-8" />
           <title>Uli</title>
-          <link rel="stylesheet" href="layout.css" />
+          <link rel="stylesheet" href="/layout.css" />
           <link rel="stylesheet" href="https://use.typekit.net/twt1ywc.css" />
           <meta name="icon" href="images/favicon-32x32.png" />
 


### PR DESCRIPTION
The problem was occurring because of the relative path of the file with the background color being present rather than the absolute path 