### PR TITLE
Rewrote existing parser with a new logic to detect tweets

### DIFF
--- a/browser-extension/plugin/src/content-script.js
+++ b/browser-extension/plugin/src/content-script.js
@@ -1,7 +1,7 @@
 import { dom } from './twitter';
 import { current } from './twitter/pages';
 const { setOnChangeListener } = dom;
-import transform from './transform';
+import transform_v2 from './transform-v2';
 import { log } from './logger';
 import repository from './repository';
 const { getPreferenceData, setPreferenceData } = repository;
@@ -24,8 +24,8 @@ function processPage(newUrl) {
             } else {
                 let timeline = getTimeline();
                 // log({ timeline });
-                transform.processNewlyAddedNodes(timeline.children);
-                setOnChangeListener(timeline, transform.processNewlyAddedNodes);
+                transform_v2.processNewlyAddedNodes_v2(timeline.children); //changed to v2 here
+                setOnChangeListener(timeline, transform_v2.processNewlyAddedNodes_v2);
             }
             clearInterval(mainLoadedChecker);
         } else {

--- a/browser-extension/plugin/src/transform-v2.js
+++ b/browser-extension/plugin/src/transform-v2.js
@@ -1,0 +1,110 @@
+import ReactDOM from 'react-dom';
+//import { parseTweet } from './twitter/parser';
+import { parseTweet_v2 } from './twitter/parser-v2';
+import { hashCode } from './util';
+import { replaceSlur } from './slur-replace';
+import { TweetControl } from './twitter/tweet-controls';
+import { log } from './logger';
+
+let tweets = {};
+
+function debug(id) {
+    console.log(id, tweets[id]);
+    // unblur(id);
+}
+
+function setBlur(id, blurFlag) {
+    if (blurFlag === true) {
+        const tweetToUnBlur = tweets[id];
+        for (let i = 0; i < tweetToUnBlur.spans.length; i++) {
+            tweetToUnBlur.spans[i].innerText = tweetToUnBlur.original_text[i];
+        }
+    } else {
+        const tweetToBlur = tweets[id];
+        for (let i = 0; i < tweetToBlur.spans.length; i++) {
+            tweetToBlur.spans[i].innerText = replaceSlur(
+                tweetToBlur.spans[i].innerText
+            );
+        }
+    }
+}
+
+function addInlineMenu(id, item, hasSlur) {
+    // const id = `ogbv_tweet_${Math.floor(Math.random() * 999999)}`;
+    // const id = hashCode(item.innerHTML);
+
+    item.setAttribute('id', id);
+
+    let inlineButtonDiv = document.createElement('div');
+    inlineButtonDiv.id = id;
+    item.prepend(inlineButtonDiv);
+
+    ReactDOM.render(
+        <TweetControl
+            tweet={tweets[id]}
+            id={id}
+            debug={debug}
+            setBlur={setBlur}
+            hasSlur={hasSlur}
+        />,
+        inlineButtonDiv
+    );
+}
+
+const processNewlyAddedNodes_v2 = function (addedNodes) {
+
+    // code for leaf
+
+    let leaf = {
+        id: undefined,
+        tweet_url: undefined,
+        original_text: [],
+        spans: []
+    };
+
+    //code for leaf ends
+
+    log('processing new nodes');
+    const nodes = Array.from(addedNodes);
+    nodes.map((node) => {
+        log('node', node);
+        const id = hashCode(node.innerHTML);
+        const output = parseTweet_v2(id, node); //renamed tweet to output -- assumed to be leaf
+        for (const individualTweet of output) {
+            individualTweet.setAttribute('id', id);
+            leaf.original_text.push(individualTweet.innerText);
+            leaf.spans.push(individualTweet);
+            log('General Tweet Leaf Identified', individualTweet);
+            leaf.tweet_url = individualTweet.parentElement.href;
+            log('General Tweet Timestamp Leaf Identified', individualTweet);
+                
+            tweets[id] = leaf;
+            let hasSlur = false;
+            for (const tweet of tweets[id].spans) {
+                const text = tweet.innerText;
+                const replacementText = replaceSlur(text);
+                tweet.innerText = replacementText;
+                if (text !== replacementText) {
+                    hasSlur = true;
+                }
+            }
+            if (
+                leaf.spans.length > 0 &&
+                node.getElementsByClassName('ogbv-tweetcontrol-bar').length == 0
+            ) {
+                addInlineMenu(id, node, hasSlur);
+            }
+        }
+        // if (
+        //     tweet.spans.length > 0 &&
+        //     node.getElementsByClassName('ogbv-tweetcontrol-bar').length == 0
+        // ) {
+        //     addInlineMenu(id, node, hasSlur);
+        // }
+    });
+};
+
+export default {
+    processNewlyAddedNodes_v2
+};
+

--- a/browser-extension/plugin/src/twitter/parser-v2.js
+++ b/browser-extension/plugin/src/twitter/parser-v2.js
@@ -13,97 +13,12 @@ import { log } from '../logger';
  * @return {Object} Tweet - stuctured tweet with values extracted from the dom
  */
 function parseTweet_v2(id, tweetDom) {
-    // const TWEET_PATH_GENERAL = new RegExp(
-    //     'ARTICLE\\(0\\):DIV\\(0\\):DIV\\(1\\):DIV\\(1\\):DIV\\(1\\):DIV\\([0-9]+\\):DIV\\(0\\):DIV\\([0-9]+\\):DIV\\([0-9]+\\):SPAN'
-    // );
-    // const TWEET_PATH_GENERAL_TIMESTAMP = new RegExp(
-    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(1\\):DIV\\(1\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(0\\):A\\(0\\):TIME'
-    // );
-    // const TWEET_PATH_MAIN = new RegExp(
-    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):SPAN'
-    // );
-    // const TWEET_PATH_MAIN_TIMESTAMP = new RegExp(
-    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(3\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):A\\(0\\):SPAN'
-    // );
-
-    // const TWEET_PATH_CLICKED = new RegExp(
-    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(1\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):SPAN'
-    // );
-    // const TWEET_PATH_CLICKED_TIMESTAMP = new RegExp(
-    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(4\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):A\\(0\\):SPAN'
-    // );
-    // let leaf = {
-    //     id,
-    //     tweet_url: undefined,
-    //     original_text: [],
-    //     spans: []
-    // };
-
-    // function DFT(node, currentPath) {
-    //     let elementTag = node.tagName;
-    //     if (elementTag == undefined) {
-    //         elementTag = 'UND';
-    //     }
-    //     node.childNodes.forEach((a, ix) => {
-    //         const newCurrentPath = currentPath + `(${ix})` + ':' + elementTag;
-    //         DFT(a, newCurrentPath);
-    //     });
-    //     if (
-    //         node.childNodes.length === 0 &&
-    //         (elementTag === 'SPAN' ||
-    //             elementTag === 'A' ||
-    //             elementTag === 'UND')
-    //     ) {
-    //         if (TWEET_PATH_GENERAL.test(currentPath)) {
-    //             const parentElement = node.parentElement;
-    //             parentElement.setAttribute('id', id);
-    //             leaf.original_text.push(parentElement.innerText);
-    //             leaf.spans.push(parentElement);
-    //             log('General Tweet Leaf Identified', node);
-    //         }
-    //         if (TWEET_PATH_GENERAL_TIMESTAMP.test(currentPath)) {
-    //             leaf.tweet_url = node.parentElement.parentElement.href;
-    //             log('General Tweet Timestamp Leaf Identified', node);
-    //         }
-
-    //         if (TWEET_PATH_MAIN.test(currentPath)) {
-    //             const parentElement = node.parentElement;
-    //             parentElement.setAttribute('id', id);
-    //             leaf.original_text.push(parentElement.innerText);
-    //             leaf.spans.push(parentElement);
-    //             log('Main Tweet Leaf Identified', node);
-    //         }
-    //         if (TWEET_PATH_MAIN_TIMESTAMP.test(currentPath)) {
-    //             leaf.tweet_url = node.parentElement.parentElement.href;
-    //             log('Main Tweet Timestamp Leaf Identified', node);
-    //         }
-
-    //         if (TWEET_PATH_CLICKED.test(currentPath)) {
-    //             const parentElement = node.parentElement;
-    //             parentElement.setAttribute('id', id);
-    //             leaf.original_text.push(parentElement.innerText);
-    //             leaf.spans.push(parentElement);
-    //             log('Main Tweet Leaf Identified', node);
-    //         }
-    //         if (TWEET_PATH_CLICKED_TIMESTAMP.test(currentPath)) {
-    //             leaf.tweet_url = node.parentElement.parentElement.href;
-    //             log('Main Tweet Timestamp Leaf Identified', node);
-    //         }
-    //     }
-    // }
-
-    // DFT(tweetDom, 'DIV');
-    const tweet = tweetDom.querySelectorAll('[data-testid="tweetText"]');
-    log(tweet);
-    // childTweet = tweet.childNodes[0];
-    return tweet;
-    // tweet.setAttribute('id', id);
-    // leaf.original_text.push(tweet.innerText);
-    // leaf.spans.push(tweet);
-    // log('General Tweet Leaf Identified', tweet);
-    // leaf.tweet_url = tweet.parentElement.href;
-    // log('General Tweet Timestamp Leaf Identified', tweet);
-    // return leaf;
+    
+    const tweet = tweetDom.querySelectorAll('[data-testid="tweetText"]'); // selects all elements that have 'tweetText' as the value of the data-testid attribute
+    // log(tweet); 
+    
+    return tweet; // returns an array of all tweet text containing DIVs
+    
 }
 
 export { parseTweet_v2 };

--- a/browser-extension/plugin/src/twitter/parser-v2.js
+++ b/browser-extension/plugin/src/twitter/parser-v2.js
@@ -1,0 +1,109 @@
+/**
+ * parser is responsible for
+ * 1. Parsing the DOM and converting it into structured tweet objects
+ */
+
+import { log } from '../logger';
+
+
+
+/**
+ * Parses the DOM and extracts structured data from it.
+ * @param {DOMElement obtained from document.getElementById query} tweetDom
+ * @return {Object} Tweet - stuctured tweet with values extracted from the dom
+ */
+function parseTweet_v2(id, tweetDom) {
+    // const TWEET_PATH_GENERAL = new RegExp(
+    //     'ARTICLE\\(0\\):DIV\\(0\\):DIV\\(1\\):DIV\\(1\\):DIV\\(1\\):DIV\\([0-9]+\\):DIV\\(0\\):DIV\\([0-9]+\\):DIV\\([0-9]+\\):SPAN'
+    // );
+    // const TWEET_PATH_GENERAL_TIMESTAMP = new RegExp(
+    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(1\\):DIV\\(1\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(0\\):A\\(0\\):TIME'
+    // );
+    // const TWEET_PATH_MAIN = new RegExp(
+    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):SPAN'
+    // );
+    // const TWEET_PATH_MAIN_TIMESTAMP = new RegExp(
+    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(3\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):A\\(0\\):SPAN'
+    // );
+
+    // const TWEET_PATH_CLICKED = new RegExp(
+    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(1\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):SPAN'
+    // );
+    // const TWEET_PATH_CLICKED_TIMESTAMP = new RegExp(
+    //     'DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):ARTICLE\\(0\\):DIV\\(0\\):DIV\\(2\\):DIV\\(4\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):DIV\\(0\\):A\\(0\\):SPAN'
+    // );
+    // let leaf = {
+    //     id,
+    //     tweet_url: undefined,
+    //     original_text: [],
+    //     spans: []
+    // };
+
+    // function DFT(node, currentPath) {
+    //     let elementTag = node.tagName;
+    //     if (elementTag == undefined) {
+    //         elementTag = 'UND';
+    //     }
+    //     node.childNodes.forEach((a, ix) => {
+    //         const newCurrentPath = currentPath + `(${ix})` + ':' + elementTag;
+    //         DFT(a, newCurrentPath);
+    //     });
+    //     if (
+    //         node.childNodes.length === 0 &&
+    //         (elementTag === 'SPAN' ||
+    //             elementTag === 'A' ||
+    //             elementTag === 'UND')
+    //     ) {
+    //         if (TWEET_PATH_GENERAL.test(currentPath)) {
+    //             const parentElement = node.parentElement;
+    //             parentElement.setAttribute('id', id);
+    //             leaf.original_text.push(parentElement.innerText);
+    //             leaf.spans.push(parentElement);
+    //             log('General Tweet Leaf Identified', node);
+    //         }
+    //         if (TWEET_PATH_GENERAL_TIMESTAMP.test(currentPath)) {
+    //             leaf.tweet_url = node.parentElement.parentElement.href;
+    //             log('General Tweet Timestamp Leaf Identified', node);
+    //         }
+
+    //         if (TWEET_PATH_MAIN.test(currentPath)) {
+    //             const parentElement = node.parentElement;
+    //             parentElement.setAttribute('id', id);
+    //             leaf.original_text.push(parentElement.innerText);
+    //             leaf.spans.push(parentElement);
+    //             log('Main Tweet Leaf Identified', node);
+    //         }
+    //         if (TWEET_PATH_MAIN_TIMESTAMP.test(currentPath)) {
+    //             leaf.tweet_url = node.parentElement.parentElement.href;
+    //             log('Main Tweet Timestamp Leaf Identified', node);
+    //         }
+
+    //         if (TWEET_PATH_CLICKED.test(currentPath)) {
+    //             const parentElement = node.parentElement;
+    //             parentElement.setAttribute('id', id);
+    //             leaf.original_text.push(parentElement.innerText);
+    //             leaf.spans.push(parentElement);
+    //             log('Main Tweet Leaf Identified', node);
+    //         }
+    //         if (TWEET_PATH_CLICKED_TIMESTAMP.test(currentPath)) {
+    //             leaf.tweet_url = node.parentElement.parentElement.href;
+    //             log('Main Tweet Timestamp Leaf Identified', node);
+    //         }
+    //     }
+    // }
+
+    // DFT(tweetDom, 'DIV');
+    const tweet = tweetDom.querySelectorAll('[data-testid="tweetText"]');
+    log(tweet);
+    // childTweet = tweet.childNodes[0];
+    return tweet;
+    // tweet.setAttribute('id', id);
+    // leaf.original_text.push(tweet.innerText);
+    // leaf.spans.push(tweet);
+    // log('General Tweet Leaf Identified', tweet);
+    // leaf.tweet_url = tweet.parentElement.href;
+    // log('General Tweet Timestamp Leaf Identified', tweet);
+    // return leaf;
+}
+
+export { parseTweet_v2 };


### PR DESCRIPTION
The earlier parser detected tweets by using RegEx queries and matching the Xpath to the tweet text elements with certain given Xpaths. 

However, I discovered that every DIV on the twitter DOM that contains a tweet text has an attribute titled 'data-testid' whose value is always 'tweetText'

Hence, the new  method uses the 'querySelectorAll()' method (ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll) of the DOM in order to select all such DIVs whose data-testid is set to tweetText. This gives an array of all DIVs in the current DOM that contain the spans which contains the tweetText. 

This array is discovered in the file parser-v2.js and then sent to the file transform-v2.js and processed there where a for loop runs through all the DIVs and does the processing that was done in transform.js

