### PR TITLE
fix: maintain proper border-radius on hover for table row with multi-…

### DIFF
--- a/uli-community/lib/uli_community_web/components/core_components.ex
+++ b/uli-community/lib/uli_community_web/components/core_components.ex
@@ -512,9 +512,9 @@ defmodule UliCommunityWeb.CoreComponents do
                 </span>
               </div>
             </td>
-            <td :if={@action != []} class="relative w-14 p-0">
+            <td :if={@action != []} class="relative w-14 p-0 group-hover:bg-slate-200 sm:rounded-r-xl">
               <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">
-                <span class="absolute -inset-y-px -right-4 left-0 group-hover:bg-slate-200 sm:rounded-r-xl" />
+                <span class="absolute -inset-y-px -right-4 left-0" />
                 <span
                   :for={action <- @action}
                   class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"


### PR DESCRIPTION
Fixes #817

---

###  Issue Description
On the Crowdsource Contributions page, when hovering over a table row where the "Meaning" column text spans multiple lines, the background hover effect loses its proper right-side border radius—the corners look squared and visually inconsistent.

###  Fix Implemented
- Moved hover background styles from inner <span> to the <td> element for full cell coverage.
- Applied `group-hover:bg-slate-200` and `sm:rounded-r-xl` directly on `<td>` .
- Tested with single-line and multi-line "Meaning" text to confirm consistent rounded corners.
 text wrapped.
- Verified behavior with both single-line and multi-line "Meaning" texts to ensure consistent rounded corners in all cases.

---

### Screenshot :

<img width="1497" height="451" alt="Screenshot from 2025-08-08 12-17-34" src="https://github.com/user-attachments/assets/bfdecc6f-a8ce-4312-93c0-209e6d7fce41" />
