### PR TITLE
Adds new filter to sort slurs by languages

### DIFF
--- a/uli-community/lib/uli_community/languages.ex
+++ b/uli-community/lib/uli_community/languages.ex
@@ -1,0 +1,39 @@
+defmodule UliCommunity.Languages do
+  import Ecto.Changeset
+
+  @codes %{
+    "asm" => "Assamese",
+    "ben" => "Bengali",
+    "brx" => "Bodo",
+    "doi" => "Dogri",
+    "guj" => "Gujarati",
+    "hin" => "Hindi",
+    "kan" => "Kannada",
+    "kas" => "Kashmiri",
+    "kok" => "Konkani",
+    "mai" => "Maithili",
+    "mal" => "Malayalam",
+    "mni" => "Manipuri",
+    "mar" => "Marathi",
+    "nep" => "Nepali",
+    "ori" => "Odiya",
+    "pan" => "Punjabi",
+    "san" => "Sanskrit",
+    "sat" => "Santhali",
+    "snd" => "Sindhi",
+    "tam" => "Tamil",
+    "tel" => "Telugu",
+    "urd" => "Urdu"
+  }
+
+  def valid_codes, do: Map.keys(@codes)
+  def all, do: @codes
+  def name(code), do: Map.get(@codes, code)
+  def select_options, do: @codes |> Enum.map(fn {code, name} -> {name, code} end) |> Enum.sort()
+
+  def validate_language(changeset, field) do
+    validate_inclusion(changeset, field, valid_codes(),
+      message: "must be a valid ISO 639-3 language code"
+    )
+  end
+end

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -5,7 +5,7 @@ defmodule UliCommunity.UserContribution do
 
   import Ecto.Query, warn: false
   alias UliCommunity.Repo
-
+  alias UliCommunity.Languages
   alias UliCommunity.UserContribution.CrowdsourcedSlur
 
   @doc """
@@ -99,15 +99,12 @@ defmodule UliCommunity.UserContribution do
   end
 
   defp filter_by_language(query, search_params) do
-    case Keyword.get(search_params, :language) do
-      "all" ->
-        query
+    language = Keyword.get(search_params, :language)
 
-      language when language in ["english", "hindi", "tamil", "bengali", "malayalam"] ->
-        from(s in query, where: s.language == ^String.to_existing_atom(language))
-
-      _ ->
-        query
+    cond do
+      language == "all" -> query
+      language in Languages.valid_codes() -> from(s in query, where: s.language == ^language)
+      true -> query
     end
   end
 

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -51,6 +51,7 @@ defmodule UliCommunity.UserContribution do
     CrowdsourcedSlur
     |> filter_by_search(search_params)
     |> filter_by_level_of_severity(search_params)
+    |> filter_by_language(search_params)
     |> filter_by_casual(search_params)
     |> filter_by_appropriated(search_params)
     |> filter_by_source(search_params)
@@ -94,6 +95,19 @@ defmodule UliCommunity.UserContribution do
       "true" -> from(s in query, where: s.appropriated == true)
       "false" -> from(s in query, where: s.appropriated == false)
       _ -> query
+    end
+  end
+
+  defp filter_by_language(query, search_params) do
+    case Keyword.get(search_params, :language) do
+      "all" ->
+        query
+
+      language when language in ["english", "hindi", "tamil", "bengali", "malayalam"] ->
+        from(s in query, where: s.language == ^String.to_existing_atom(language))
+
+      _ ->
+        query
     end
   end
 
@@ -306,6 +320,13 @@ defmodule UliCommunity.UserContribution do
     UliCommunity.UserContribution.CrowdsourcedSlur
     |> group_by([s], s.level_of_severity)
     |> select([s], %{label: s.level_of_severity, count: count(s.id)})
+    |> Repo.all()
+  end
+
+  def get_language do
+    UliCommunity.UserContribution.CrowdsourcedSlur
+    |> group_by([s], s.language)
+    |> select([s], %{label: s.language, count: count(s.id)})
     |> Repo.all()
   end
 

--- a/uli-community/lib/uli_community/user_contribution/crowdsourced_slur.ex
+++ b/uli-community/lib/uli_community/user_contribution/crowdsourced_slur.ex
@@ -12,6 +12,7 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
              :appropriation_context,
              :meaning,
              :categories,
+             :language,
              :contributor_user_id,
              :inserted_at,
              :updated_at,
@@ -21,6 +22,7 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
   schema "crowdsourced_slurs" do
     field(:label, :string)
     field(:level_of_severity, Ecto.Enum, values: [:low, :medium, :high])
+    field(:language, Ecto.Enum, values: [:english, :hindi, :tamil, :bengali, :malayalam])
     field(:casual, :boolean)
     field(:appropriated, :boolean)
     field(:appropriation_context, :boolean, default: nil)
@@ -56,6 +58,7 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
     |> cast(attrs, [
       :label,
       :level_of_severity,
+      :language,
       :casual,
       :appropriated,
       :appropriation_context,
@@ -100,6 +103,7 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
     |> cast(attrs, [
       :label,
       :level_of_severity,
+      :language,
       :casual,
       :appropriated,
       :appropriation_context,

--- a/uli-community/lib/uli_community/user_contribution/crowdsourced_slur.ex
+++ b/uli-community/lib/uli_community/user_contribution/crowdsourced_slur.ex
@@ -1,6 +1,7 @@
 defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
   use Ecto.Schema
   import Ecto.Changeset
+  alias UliCommunity.Languages
 
   @derive {Jason.Encoder,
            only: [
@@ -19,10 +20,11 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
              :page_url
            ]}
 
+
   schema "crowdsourced_slurs" do
     field(:label, :string)
     field(:level_of_severity, Ecto.Enum, values: [:low, :medium, :high])
-    field(:language, Ecto.Enum, values: [:english, :hindi, :tamil, :bengali, :malayalam])
+    field(:language, :string)
     field(:casual, :boolean)
     field(:appropriated, :boolean)
     field(:appropriation_context, :boolean, default: nil)
@@ -80,6 +82,7 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
       :contributor_user_id,
       :source
     ])
+    |> Languages.validate_language(:language)
   end
 
   def changeset_only_label(crowdsourced_slur, attrs) do
@@ -118,5 +121,6 @@ defmodule UliCommunity.UserContribution.CrowdsourcedSlur do
       :label,
       :source
     ])
+    |> Languages.validate_language(:language)
   end
 end

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.ex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.ex
@@ -6,6 +6,7 @@ defmodule UliCommunityWeb.CrowdsourceContributionsLive do
   alias UliCommunityWeb.CrowdsourceContributionsSearchParams
 
   alias UliCommunity.UserContribution
+  alias UliCommunity.Languages
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -16,7 +17,6 @@ defmodule UliCommunityWeb.CrowdsourceContributionsLive do
     end
 
     user_role = socket.assigns.current_user.role
-
     {:ok,
      assign(socket,
        slurs_metadata_list: [],
@@ -29,7 +29,8 @@ defmodule UliCommunityWeb.CrowdsourceContributionsLive do
        search_params: [],
        query_count: 0,
        advanced_search: false,
-       vector_search_loading: false
+       vector_search_loading: false,
+       language_options: Languages.select_options()
      )}
   end
 
@@ -238,6 +239,18 @@ defmodule UliCommunityWeb.CrowdsourceContributionsLive do
       end
 
     {:noreply, socket}
+  end
+
+  def handle_event("change-language", %{"language" => code}, socket) do
+    search_params = Keyword.put(socket.assigns.search_params, :language, code)
+
+    {:noreply,
+     socket
+     |> assign(:search_params, search_params)
+     |> push_navigate(
+       to:
+         "/crowdsource-contributions?#{CrowdsourceContributionsSearchParams.search_param_string(search_params)}"
+     )}
   end
 
   def handle_event("close-modal", _unsigned_params, socket) do

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
@@ -340,8 +340,10 @@
       <div>
         <p class="py-2">Language</p>
         <form phx-change="change-language">
+          <label for="language-filter" class="sr-only">Language</label>
           <select
             name="language"
+            id="language-filter"
             class="border border-gray-300 rounded p-2 text-sm w-auto"
           >
             <option value="all" selected={Keyword.get(@search_params, :language) == "all"}>

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
@@ -139,7 +139,7 @@
     <!-- Clear Filters (only tablet/laptop and larger) -->
     <.link
       href={
-        ~p"/crowdsource-contributions?page_num=1&sort=newest&level_of_severity=all&casual=all&appropriated=all&source=all"
+        ~p"/crowdsource-contributions?page_num=1&sort=newest&level_of_severity=all&language=all&casual=all&appropriated=all&source=all"
       }
       class="hidden md:inline-flex mt-4 items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 transition-colors"
     >
@@ -333,6 +333,54 @@
             value="all"
             label="All"
             selection={Keyword.get(@search_params, :source)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Language</p>
+        <div>
+          <.input_radio
+            name="language"
+            id="english"
+            value="english"
+            label="English"
+            selection={Keyword.get(@search_params, :language)}
+          />
+          <.input_radio
+            name="language"
+            id="hindi"
+            value="hindi"
+            label="Hindi"
+            selection={Keyword.get(@search_params, :language)}
+          />
+          <.input_radio
+            name="language"
+            id="tamil"
+            value="tamil"
+            label="Tamil"
+            selection={Keyword.get(@search_params, :language)}
+          />
+          <.input_radio
+            name="language"
+            id="bengali"
+            value="bengali"
+            label="Bengali"
+            selection={Keyword.get(@search_params, :language)}
+          />
+          <.input_radio
+            name="language"
+            id="malayalam"
+            value="malayalam"
+            label="Malayalam"
+            selection={Keyword.get(@search_params, :language)}
+          />
+          <.input_radio
+            name="language"
+            id="language_all"
+            value="all"
+            label="All"
+            selection={Keyword.get(@search_params, :language)}
           />
         </div>
       </div>
@@ -683,6 +731,7 @@
       <.table id="crowdsource-slur-metadata-table" rows={@slurs_metadata_list}>
         <:col :let={slur} label="Slur's Label"><%= slur.label %></:col>
         <:col :let={slur} label="Level of Severity"><%= slur.level_of_severity || "-" %></:col>
+        <:col :let={slur} label="Language"><%= slur.language || "-" %></:col>
         <:col :let={slur} label="Is Casual?">
           <%= if is_nil(slur.casual), do: "-", else: (slur.casual == true && "Yes") || "No" %>
         </:col>

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
@@ -40,7 +40,7 @@
         required
         label="Language"
         type="select"
-        options={[{"English", :en}, {"Hindi", :hi}, {"Tamil", :ta}]}
+        options={@language_options}
         field={@slur_form[:language]}
       />
     </div>
@@ -339,50 +339,21 @@
 
       <div>
         <p class="py-2">Language</p>
-        <div>
-          <.input_radio
+        <form phx-change="change-language">
+          <select
             name="language"
-            id="english"
-            value="english"
-            label="English"
-            selection={Keyword.get(@search_params, :language)}
-          />
-          <.input_radio
-            name="language"
-            id="hindi"
-            value="hindi"
-            label="Hindi"
-            selection={Keyword.get(@search_params, :language)}
-          />
-          <.input_radio
-            name="language"
-            id="tamil"
-            value="tamil"
-            label="Tamil"
-            selection={Keyword.get(@search_params, :language)}
-          />
-          <.input_radio
-            name="language"
-            id="bengali"
-            value="bengali"
-            label="Bengali"
-            selection={Keyword.get(@search_params, :language)}
-          />
-          <.input_radio
-            name="language"
-            id="malayalam"
-            value="malayalam"
-            label="Malayalam"
-            selection={Keyword.get(@search_params, :language)}
-          />
-          <.input_radio
-            name="language"
-            id="language_all"
-            value="all"
-            label="All"
-            selection={Keyword.get(@search_params, :language)}
-          />
-        </div>
+            class="border border-gray-300 rounded p-2 text-sm w-auto"
+          >
+            <option value="all" selected={Keyword.get(@search_params, :language) == "all"}>
+              All
+            </option>
+            <%= for {name, code} <- @language_options do %>
+              <option value={code} selected={Keyword.get(@search_params, :language) == code}>
+                <%= name %>
+              </option>
+            <% end %>
+          </select>
+        </form>
       </div>
 
       <div>

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_search_params.ex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_search_params.ex
@@ -1,6 +1,7 @@
 defmodule UliCommunityWeb.CrowdsourceContributionsSearchParams do
   @allowed_filter_keys [
     "level_of_severity",
+    "language",
     "casual",
     "appropriated",
     "source",
@@ -17,6 +18,7 @@ defmodule UliCommunityWeb.CrowdsourceContributionsSearchParams do
       page_num: "1",
       sort: "newest",
       level_of_severity: "all",
+      language: "all",
       casual: "all",
       appropriated: "all",
       source: "all",
@@ -71,6 +73,9 @@ defmodule UliCommunityWeb.CrowdsourceContributionsSearchParams do
 
       "level_of_severity" ->
         Keyword.put(search_params, :level_of_severity, value["value"])
+
+      "language" ->
+        Keyword.put(search_params, :language, value["value"])
 
       "casual" ->
         Keyword.put(search_params, :casual, value["value"])

--- a/uli-community/priv/repo/migrations/20250120074709_create_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/migrations/20250120074709_create_crowdsourced_slurs.exs
@@ -3,7 +3,6 @@ defmodule UliCommunity.Repo.Migrations.CreateCrowdsourcedSlurs do
 
   def change do
     execute("CREATE TYPE level_of_severity AS ENUM ('low', 'medium', 'high')")
-    execute("CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')")
     execute("CREATE TYPE category_enum AS ENUM ('gendered',
     'sexualized',
     'religion',
@@ -24,7 +23,6 @@ defmodule UliCommunity.Repo.Migrations.CreateCrowdsourcedSlurs do
       add(:appropriation_context, :boolean, null: true)
       add(:meaning, :text)
       add(:categories, {:array, :category_enum})
-      add(:language, :language_enum)
       add(:contributor_user_id, references(:users, on_delete: :delete_all), null: false)
 
       timestamps(type: :utc_datetime)

--- a/uli-community/priv/repo/migrations/20250120074709_create_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/migrations/20250120074709_create_crowdsourced_slurs.exs
@@ -3,6 +3,7 @@ defmodule UliCommunity.Repo.Migrations.CreateCrowdsourcedSlurs do
 
   def change do
     execute("CREATE TYPE level_of_severity AS ENUM ('low', 'medium', 'high')")
+    execute("CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')")
     execute("CREATE TYPE category_enum AS ENUM ('gendered',
     'sexualized',
     'religion',
@@ -23,6 +24,7 @@ defmodule UliCommunity.Repo.Migrations.CreateCrowdsourcedSlurs do
       add(:appropriation_context, :boolean, null: true)
       add(:meaning, :text)
       add(:categories, {:array, :category_enum})
+      add(:language, :language_enum)
       add(:contributor_user_id, references(:users, on_delete: :delete_all), null: false)
 
       timestamps(type: :utc_datetime)

--- a/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
@@ -1,0 +1,11 @@
+defmodule UliCommunity.Repo.Migrations.AddLanguageToCrowdsourcedSlurs do
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')")
+
+    alter table(:crowdsourced_slurs) do
+      add(:language, :language_enum)
+    end
+  end
+end

--- a/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
@@ -2,7 +2,10 @@ defmodule UliCommunity.Repo.Migrations.AddLanguageToCrowdsourcedSlurs do
   use Ecto.Migration
 
   def change do
-    execute("CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')")
+    execute(
+      "CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')",
+      "DROP TYPE language_enum"
+    )
 
     alter table(:crowdsourced_slurs) do
       add(:language, :language_enum)

--- a/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/migrations/20260707090000_add_language_to_crowdsourced_slurs.exs
@@ -2,13 +2,8 @@ defmodule UliCommunity.Repo.Migrations.AddLanguageToCrowdsourcedSlurs do
   use Ecto.Migration
 
   def change do
-    execute(
-      "CREATE TYPE language_enum AS ENUM ('hindi', 'english', 'tamil', 'bengali', 'malayalam')",
-      "DROP TYPE language_enum"
-    )
-
     alter table(:crowdsourced_slurs) do
-      add(:language, :language_enum)
+      add(:language, :string, size: 3)
     end
   end
 end

--- a/uli-community/priv/repo/seed_crowdsourced_slurs.exs
+++ b/uli-community/priv/repo/seed_crowdsourced_slurs.exs
@@ -3,408 +3,476 @@ alias UliCommunity.UserContribution
 slurs = [
   %{
     label: "sunrise",
+    language: "hin",
     page_url: "https://example.com/sunrise",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "whisper",
+    language: "tam",
     page_url: "https://example.com/whisper",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "breeze",
+    language: "ben",
     page_url: "https://example.com/breeze",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "echo",
+    language: "mal",
     page_url: "https://example.com/echo",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "tel",
     page_url: "https://example.com/spark",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glimmer",
+    language: "mar",
     page_url: "https://example.com/glimmer",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "wave",
+    language: "guj",
     page_url: "https://example.com/wave",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flutter",
+    language: "pan",
     page_url: "https://example.com/flutter",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "dawn",
+    language: "urd",
     page_url: "https://example.com/dawn",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glow",
+    language: "kan",
     page_url: "https://example.com/glow",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "mist",
+    language: "ori",
     page_url: "https://example.com/mist",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "cloud",
+    language: "asm",
     page_url: "https://example.com/cloud",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "mai",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "hin",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "tam",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "ben",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "mal",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "tel",
     page_url: "https://example.com/ray",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "drift",
+    language: "mar",
     page_url: "https://example.com/drift",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flicker",
+    language: "guj",
     page_url: "https://example.com/flicker",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "pulse",
+    language: "pan",
     page_url: "https://example.com/pulse",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "trail",
+    language: "urd",
     page_url: "https://example.com/trail",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "bloom",
+    language: "kan",
     page_url: "https://example.com/bloom",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glide",
+    language: "ori",
     page_url: "https://example.com/glide",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "asm",
     page_url: "https://example.com/spark2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "whisper",
+    language: "hin",
     page_url: "https://example.com/whisper2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flutter",
+    language: "tam",
     page_url: "https://example.com/flutter2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "dawn",
+    language: "ben",
     page_url: "https://example.com/dawn2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ripple",
+    language: "mal",
     page_url: "https://example.com/ripple2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "echo",
+    language: "tel",
     page_url: "https://example.com/echo2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glimmer",
+    language: "mar",
     page_url: "https://example.com/glimmer2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "breeze",
+    language: "guj",
     page_url: "https://example.com/breeze2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "mist",
+    language: "pan",
     page_url: "https://example.com/mist2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "cloud",
+    language: "urd",
     page_url: "https://example.com/cloud2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glow",
+    language: "kan",
     page_url: "https://example.com/glow2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "ray",
+    language: "ori",
     page_url: "https://example.com/ray2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "drift",
+    language: "asm",
     page_url: "https://example.com/drift2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flicker",
+    language: "hin",
     page_url: "https://example.com/flicker2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "pulse",
+    language: "tam",
     page_url: "https://example.com/pulse2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "trail",
+    language: "ben",
     page_url: "https://example.com/trail2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "bloom",
+    language: "mal",
     page_url: "https://example.com/bloom2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glide",
+    language: "tel",
     page_url: "https://example.com/glide2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "sunrise",
+    language: "mar",
     page_url: "https://example.com/sunrise2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "sparkle",
+    language: "guj",
     page_url: "https://example.com/sparkle",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "shine",
+    language: "pan",
     page_url: "https://example.com/shine",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "wavelet",
+    language: "urd",
     page_url: "https://example.com/wavelet",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "twinkle",
+    language: "kan",
     page_url: "https://example.com/twinkle",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glint",
+    language: "ori",
     page_url: "https://example.com/glint",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "rayon",
+    language: "asm",
     page_url: "https://example.com/rayon",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "zephyr",
+    language: "hin",
     page_url: "https://example.com/zephyr",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "bask",
+    language: "tam",
     page_url: "https://example.com/bask",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glowworm",
+    language: "ben",
     page_url: "https://example.com/glowworm",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flutterby",
+    language: "mal",
     page_url: "https://example.com/flutterby",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "luster",
+    language: "tel",
     page_url: "https://example.com/luster",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "mar",
     page_url: "https://example.com/spark",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "guj",
     page_url: "https://example.com/spark2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "pan",
     page_url: "https://example.com/spark3",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "spark",
+    language: "urd",
     page_url: "https://example.com/spark4",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "whisper",
+    language: "kan",
     page_url: "https://example.com/whisper",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "whisper",
+    language: "ori",
     page_url: "https://example.com/whisper2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flutter",
+    language: "asm",
     page_url: "https://example.com/flutter",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "flutter",
+    language: "hin",
     page_url: "https://example.com/flutter2",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "sunrise",
+    language: "tam",
     page_url: "https://example.com/sunrise",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "echo",
+    language: "ben",
     page_url: "https://example.com/echo",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "breeze",
+    language: "mal",
     page_url: "https://example.com/breeze",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "glimmer",
+    language: "tel",
     page_url: "https://example.com/glimmer",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "wave",
+    language: "mar",
     page_url: "https://example.com/wave",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise
   },
   %{
     label: "dawn",
+    language: "guj",
     page_url: "https://example.com/dawn",
     contributor_user_id: "1",
     source: :crowdsourcing_exercise


### PR DESCRIPTION
---
name: Enhancement
about: Adds new filter to sort slurs by languages
title: 'Adds new filter to sort slurs by languages'
labels: Enhancement
assignees: yash01699

---

**Describe the PR**
Adds language-based filtering to the crowdsourced slurs dashboard, closes #949.

- Added a `language` column (`hindi | english | tamil | bengali | malayalam`) to the `crowdsourced_slurs` table via a Postgres enum type, defined in the existing `create_crowdsourced_slurs` migration.
- Added `:language` to the `CrowdsourcedSlur` schema (`Ecto.Enum`) and to the `cast`/allowed-attrs lists of `changeset/2` and `changeset_seed/2` so it can actually be persisted.
- Added a `filter_by_language/2` clause to `UserContribution.build_filtered_query/1`, wired into `list_crowdsourced_slurs_with_filters/1` alongside the existing severity/casual/appropriated/source/category filters.
- Added `"language"` as an allowed/query-string filter key in `CrowdsourceContributionsSearchParams`, with an `"all"` default and `update_search_param/2` handling, matching the pattern used for the other radio filters.
- Added a "Language" filter section (radio buttons: English / Hindi / Tamil / Bengali / Malayalam / All) to the sidebar on `/crowdsource-contributions`, a "Language" column to the results table, and included `language=all` in the "Clear All Filters" link.

**Steps to test the PR**
1. Run `mix ecto.migrate` to pick up the new `language` column (or `mix ecto.reset` on a fresh DB).
2. Seed or manually create a few `crowdsourced_slurs` rows with different `language` values (e.g. via `iex -S mix`: `UliCommunity.UserContribution.create_crowdsourced_slur_seed(%{label: "test", source: :crowdsourcing_exercise, language: :hindi, contributor_user_id: <a-valid-user-id>})`).
3. Visit `/crowdsource-contributions` while logged in.
4. In the left sidebar filter panel, click through the new "Language" radio options (English, Hindi, Tamil, Bengali, Malayalam, All) and confirm the results list and "Showing all N contributions" count update to match only rows with that language.
5. Confirm the results table now shows a "Language" column, and rows without a language tagged show "-".
6. Combine the language filter with an existing filter (e.g. Level of Severity or the search box) and confirm both apply together (AND logic).
7. Click "Clear All Filters" and confirm the language filter resets to "All".

**Expected behavior**
Contributors can narrow the crowdsourced slurs list to a specific language the same way they can already filter by severity, source, or category, making it easier to spot which languages are under-represented and target contributions accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-based filtering for crowdsource contributions (with an “All” option) across the search sidebar, approval modal, and URL query params.
  * Added language support to crowdsourced slurs, including a new Language column and language breakdown statistics.
* **Bug Fixes**
  * “Clear All Filters” now resets the language filter too.
* **Chores**
  * Added a database migration and expanded seed data to persist and validate language for crowdsourced slurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Steps to test :
- Seed the database with slurs with language field - `mix run priv/repo/seed_crowdsourced_slurs.exs`
- Start the app and visit localhost:4000
- Login as a user and visit the `/crowdsource-contributions` route
- Change the language filter to "Assamese"

#### Expected Results
- the slur list in the right column will filter to only contain slurs with the language assamese
- You will see `language=urd` in the query path in the browser URL 