### PR TITLE
Add About link to the navigation bar

### DIFF
--- a/uli-website/src/components/molecules/NavBarNew.jsx
+++ b/uli-website/src/components/molecules/NavBarNew.jsx
@@ -64,9 +64,9 @@ export default function NavBarNew() {
           {/* <NavLinkNew to="#">
             <Text className="text-[16px] font-medium">Contact</Text>
           </NavLinkNew> */}
-          {/* <NavLinkNew to="/about">
-            <Text className="text-[16px] font-medium">About us</Text>
-          </NavLinkNew> */}
+          <NavLinkNew to="/about">
+            <Text className="text-[16px] font-medium">About</Text>
+          </NavLinkNew>
           <NavLinkNew to="/blog">
             <Text className="text-[16px] font-medium">Blog</Text>
           </NavLinkNew>
@@ -78,9 +78,9 @@ export default function NavBarNew() {
 
       <Box className={`bg-[#FFE7D9] w-full text-center overflow-hidden transition-all duration-300 ease-in-out ${open ? "max-h-96 opacity-100 mt-9 mb-4" : "max-h-0 opacity-0"} lg:hidden`}>
         <Box className="flex flex-col gap-5 py-6">
-          {/* <NavLinkNew to="/about">
-            <Text className="text-[16px] font-medium">About us</Text>
-          </NavLinkNew> */}
+          <NavLinkNew to="/about">
+            <Text className="text-[16px] font-medium">About</Text>
+          </NavLinkNew>
           <NavLinkNew to="/blog">
             <Text className="text-[16px] font-medium">Blog</Text>
           </NavLinkNew>


### PR DESCRIPTION
## Summary

This PR makes the **About** page accessible from the Uli homepage navigation.

### Changes Made

* Uncommented the existing `NavLinkNew` code for the **About** page in the desktop navigation.
* Uncommented the existing `NavLinkNew` code for the **About** page in the mobile navigation menu.
* Updated the link text from **"About us"** to **"About"**.

### Result

The **About** link is now visible alongside the **Blog** and **Research** links on the homepage. It works correctly in both desktop and mobile layouts and navigates users to the `/about` page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an active “About” link to both desktop and mobile navigation menus.
  * The link directs visitors to the About page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->