### PR TITLE
feat: make advanced search work in prod, changes in Dockerfile

### DIFF
--- a/uli-community/.dockerignore
+++ b/uli-community/.dockerignore
@@ -43,3 +43,7 @@ erl_crash.dump
 /assets/node_modules/
 /priv/static/assets/
 /priv/static/cache_manifest.json
+
+# Python venv and model cache - installed/downloaded inside the container, not needed in build context
+/lib/python/.venv/
+/lib/python/.cache/

--- a/uli-community/.env.local.example
+++ b/uli-community/.env.local.example
@@ -1,0 +1,17 @@
+AWS_ACCESS_KEY_ID=randomsecretkeyid
+AWS_SECRET_ACCESS_KEY=randomsecretkey
+# DATABASE_HOSTNAME must be "db" - that's the db service's name on the
+# compose network, not localhost.
+DATABASE_HOSTNAME=db
+DATABASE_NAME=uli_community_prod
+DATABASE_PASSWORD=weak_password
+DATABASE_USER=uli_community
+PHX_HOST=localhost
+PHX_SERVER=true
+PORT=4000
+POOL_SIZE=10
+# Any random secret key. Can be generated with "mix phx.gen.secret"
+SECRET_KEY_BASE=SomeRandomSecretKeyjjdjd
+SLACK_WEBHOOK_URL=randomwebhookurl
+# This is used to avoid configuring AWS email adapter, and plug the Swoosh adapter instead. 
+MAILER_ADAPTER=local

--- a/uli-community/.gitignore
+++ b/uli-community/.gitignore
@@ -41,3 +41,6 @@ npm-debug.log
 .venv/
 **__pycache__/
 **uv.lock
+
+.env*
+!.env.local.example

--- a/uli-community/Dockerfile
+++ b/uli-community/Dockerfile
@@ -11,19 +11,25 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.17.2-erlang-27.0-debian-bullseye-20240701-slim
 #
-ARG ELIXIR_VERSION=1.18.2
-ARG OTP_VERSION=27.2.1
-ARG DEBIAN_VERSION=ubuntu-jammy-20240808
-ARG RUNNER_DEBIAN_VERSION=jammy-20240808
+# 1.18.4-erlang-27.3.4.14-ubuntu-jammy-20260627 <- Current Image
+ARG ELIXIR_VERSION=1.18.4
+ARG OTP_VERSION=27.3.4.14
+ARG DEBIAN_VERSION=ubuntu-jammy-20260627
+ARG RUNNER_DEBIAN_VERSION=jammy-20260627
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="ubuntu:${RUNNER_DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 
-# install build dependencies
+# install build dependencies and python
 RUN apt-get update -y && apt-get install -y build-essential git npm \
+  python3 python3-venv curl \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
 
 # prepare build dir
 WORKDIR /app
@@ -50,6 +56,18 @@ COPY priv priv
 
 COPY lib lib
 
+# set up the python venv, install deps, and pre-download the
+# vyakyarth model weights used in advanced search. 
+# HF_HOME pins the download location inside the project dir 
+# instead of the default ~/.cache,
+# so it's copyable into the runner stage below.
+# This is its own layer, so it's only re-run (and only re-downloads)
+# when lib/python actually changes - unrelated app changes (CSS, other
+# .ex files, etc.) reuse the cached layer.
+ENV HF_HOME=/app/lib/python/.cache/huggingface
+RUN cd lib/python && uv venv && uv pip install -r pyproject.toml \
+  && .venv/bin/python -c "import text_vec; text_vec.initialize()"
+
 COPY assets assets
 
 RUN npm install --prefix assets
@@ -72,6 +90,7 @@ FROM ${RUNNER_IMAGE}
 
 RUN apt-get update -y && \
   apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
+  python3 python3-venv \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale
@@ -87,6 +106,12 @@ RUN chown nobody /app
 # set runner ENV
 ENV MIX_ENV="prod"
 
+# bring the python venv (deps + pre-downloaded model cache)
+# into the runner image, and point HF_HOME at the same spot so the
+# app finds the model without re-downloading it at runtime.
+COPY --from=builder --chown=nobody:root /app/lib/python /app/lib/python
+ENV HF_HOME=/app/lib/python/.cache/huggingface
+
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/uli_community ./
 
@@ -97,4 +122,4 @@ USER nobody
 # above and adding an entrypoint. See https://github.com/krallin/tini for details
 # ENTRYPOINT ["/tini", "--"]
 
-CMD ["/app/bin/server"]
+CMD ["/app/bin/uli_community", "start"]

--- a/uli-community/config/prod.exs
+++ b/uli-community/config/prod.exs
@@ -23,3 +23,8 @@ config :logger, level: :info
 
 # text vec genserver for prod setup
 config :uli_community, :enable_text_vec_rep_vyakyarth, true
+
+# Configure Python
+config :uli_community, :python,
+  python: "/app/lib/python/.venv/bin/python",
+  python_path: "/app/lib/python"

--- a/uli-community/config/runtime.exs
+++ b/uli-community/config/runtime.exs
@@ -122,9 +122,16 @@ if config_env() == :prod do
   # Check `Plug.SSL` for all available options in `force_ssl`.
 
   # ## Configuring the mailer
-  config :uli_community, UliCommunity.Mailer,
-    adapter: Swoosh.Adapters.AmazonSES,
-    region: "ap-south-1",
-    access_key: aws_access_key_id,
-    secret: aws_secret_access_key
+  # MAILER_ADAPTER=local switches to Swoosh's in-memory adapter, useful when
+  # running a prod-like build locally without real AWS SES creds. Any other
+  # value (including unset, as in real prod) keeps the SES adapter.
+  if System.get_env("MAILER_ADAPTER") == "local" do
+    config :uli_community, UliCommunity.Mailer, adapter: Swoosh.Adapters.Local
+  else
+    config :uli_community, UliCommunity.Mailer,
+      adapter: Swoosh.Adapters.AmazonSES,
+      region: "ap-south-1",
+      access_key: aws_access_key_id,
+      secret: aws_secret_access_key
+  end
 end

--- a/uli-community/docker-compose.prod.yml
+++ b/uli-community/docker-compose.prod.yml
@@ -1,0 +1,54 @@
+# A docker compose that spins up the DB, DB-GUI and the Phoenix App. 
+# Can be used to test how the app would work in the production. 
+# The App uses an .env.local environment file. It can be copied from the .env.local.example file.
+name: uli-community-prod
+
+services:
+  db:
+    image: pgvector/pgvector:pg14
+    restart: always
+    environment:
+      - POSTGRES_USER=uli_community
+      - POSTGRES_PASSWORD=weak_password
+      - POSTGRES_DB=uli_community_prod
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - ~/data/uli_community_prod/postgres:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+
+  db_gui:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+  migrate:
+    image: uli-community:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.local
+    depends_on:
+      db:
+        condition: service_healthy
+    command: [ "/app/bin/uli_community", "eval", "UliCommunity.Release.migrate()" ]
+
+  app:
+    image: uli-community:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    env_file:
+      - .env.local
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - 4000:4000


### PR DESCRIPTION
This PR allows advanced search in uli-community prod. This PR also fixes the Docker build issue in the GitHub workflow for uli-community.

## Docker Build issue fix
This is a separate issue that came into picture a few months back. Example failure: https://github.com/tattle-made/Uli/actions/runs/29162032951/job/86568658190
The Docker build has been failing on mix local.hex with a TLS certificate error:
```
{:failed_connect, [{:to_address, {~c"builds.hex.pm", 443}}, ...
{tls_alert, {:unsupported_certificate, ... key_usage_mismatch}}]}
```

This was caused by the base image being pinned to a snapshot from August 2024 (ubuntu-jammy-20240808), whose bundled ca-certificates no longer validates hex.pm's current certificate chain.

Fix: bumped the base image to a recent jammy snapshot (hexpm/elixir:1.18.4-erlang-27.3.4.14-ubuntu-jammy-20260627 for the builder, ubuntu:jammy-20260627 for the runner), which ships an up-to-date trust store and resolves the handshake failure.

## Changes in the Dockerfile

### Replace the command at the end
The previous command `CMD ["/app/bin/server"]` has been replaced with `CMD ["/app/bin/uli_community", "start"]`. 

In the deployment, we are forcefully running the `CMD ["/app/bin/uli_community", "start"]` command instead of relying on the existing one; that is why there were no errors while starting the prod server. But when I tried running the image locally, the existing command was failing. There was no such directory as "/app/bin/server" in the built app. 

### Added the Commands for Python installation
- Added commands to install Python, uv, and other dependencies. 
- Executing the text_vec.initialize() command during build time itself, to download the model during build time. 
- The comments explaining the newly added lines in the Dockerfile can be viewed to understand every change in detail.  

## New docker-compose.prod added

Adds a new `docker-compose.prod.yml`, alongside the existing dev-only `docker-compose.yml` (which is untouched), to make it possible to run the whole app, Postgres, Adminer, and the Phoenix app itself, as it would actually run in production, entirely locally. Previously there was no easy way to sanity-check a release build (migrations, runtime config, the compiled release itself) before it went anywhere near a real environment; now it's one command.

**What's included:**
- `db` and `db_gui: same as in the existing docker-compose file. 
- `migrate`: to run migrations
- `app`: the Phoenix app

**Configuration:**
- All runtime config (DB creds, `SECRET_KEY_BASE`, AWS keys, Slack webhook, `PHX_HOST`, etc.) is supplied via an `.env.local` file, wired in through `env_file` on both the `migrate` and `app` services. 
- `.env.local.example` is added as a checked-in template with every variable the app needs at boot. This file can be used as it is to produce `.env.local`.
- Note that the `DATABASE_HOSTNAME` must be `db` (the Compose service name, not `localhost`), since the app talks to Postgres over the Compose network. 

**Mailer adapter change (`config/runtime.exs`):**
- `runtime.exs` previously hardcoded the mailer to `Swoosh.Adapters.AmazonSES` any time `config_env() == :prod`, which meant a prod-style build could never boot cleanly without real AWS SES credentials, and any email-sending code path would hard fail against fake ones.
- Added a `MAILER_ADAPTER` env var check: if `MAILER_ADAPTER=local` is set, the app uses Swoosh's in-memory `Local` adapter instead, so email sends succeed locally without needing real AWS creds. If the var is unset, the normal AWS adapter is set. 

## Container Resource Usage

**Image size:** The final image size has grown to around 6.5GB, up from the previous 138MB baseline. This is mainly due to PyTorch and the pre-downloaded model being baked into the image at build time. 

I ran a full local test cycle to get a sense of real-world resource usage: running the seeding script on around 1400 entries, followed by a few advanced search queries, while monitoring the container in Docker Desktop.

The following stats were monitored through the Docker Desktop UI and took **Claude's help** to analyse the graphs:

<img width="3270" height="1825" alt="Screenshot from 2026-08-13 15-02-56" src="https://github.com/user-attachments/assets/650c2ecd-3261-4840-8425-7e5991e791f9" />


**CPU:** Stayed near idle for most of the run, with a spike to around 730% during the batch embedding step. This is expected, since PyTorch parallelizes inference across available cores by default.

**Memory:** Climbed to about 950MB once the model loaded into memory, then rose to around 1.63GB during the seeding batch and stayed flat afterward, with no signs of a leak.

**Disk and network:** Disk reads jumped during the same seeding window. Network I/O showed small, separate step increases corresponding to each individual search query, much lighter than the seeding batch.

**NOTE:**
Merging this now to verify the GitHub workflow runs successfully end to end. Will address the last 2 CodeRabbit comments (pinning the uv installer, committing uv.lock and using uv sync --locked) in a follow up PR. Skipping for now since the image is quite large and any change here needs a full local build and test cycle before pushing, which takes a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production deployment support with Docker Compose, PostgreSQL with vector search, database migrations, and optional Adminer access.
  * Enabled text vector functionality and Python model integration.
  * Added configurable email delivery, including a local mailer option for development.
  * Added a sample environment configuration covering database, AWS, mailer, and application settings.
* **Chores**
  * Updated container builds to include Python dependencies and preloaded model assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->