### PR TITLE
feat: add cluster visualization, improve ranking in advanced search

### DIFF
--- a/uli-community/assets/css/app.css
+++ b/uli-community/assets/css/app.css
@@ -11,4 +11,17 @@
 
 @theme {
   --color-brand: #FD4F00;
+
+  /* Crowdsourced slur labels span ~22 Indian languages across a dozen
+     scripts (see UliCommunity.Languages). The original system-font stack
+     stays first so English/Latin text renders unchanged; the Noto script
+     families are appended purely as fallbacks, so the browser only reaches
+     for them when the system font has no glyph for a character (e.g. Tamil)
+     instead of falling back all the way to tofu boxes. */
+  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji",
+    "Noto Sans Devanagari", "Noto Sans Bengali", "Noto Sans Gujarati",
+    "Noto Sans Gurmukhi", "Noto Sans Kannada", "Noto Sans Malayalam",
+    "Noto Sans Oriya", "Noto Sans Tamil", "Noto Sans Telugu",
+    "Noto Sans Meetei Mayek", "Noto Sans Ol Chiki", "Noto Sans Arabic";
 }

--- a/uli-community/assets/js/app.js
+++ b/uli-community/assets/js/app.js
@@ -27,6 +27,7 @@ import { PieChartHook } from "./hooks/pie_chart_hook";
 import { BarChartHook } from "./hooks/bar_chart_hook.js";
 import { SourceBarChartHook } from "./hooks/source_bar_chart_hook.js";
 import { WeeklyLineChartHook } from "./hooks/weekly_line_chart_hook.js";
+import { ClusterBubbleChartHook } from "./hooks/cluster_bubble_chart_hook.js";
 
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -38,6 +39,7 @@ Hooks.BarChartHook = BarChartHook
 Hooks.SourceBarChartHook = SourceBarChartHook
 Hooks.WeeklyLineChartHook = WeeklyLineChartHook
 Hooks.DateSelector = DateSelectorHook;
+Hooks.ClusterBubbleChartHook = ClusterBubbleChartHook;
 
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,

--- a/uli-community/assets/js/cluster_bubble_chart.js
+++ b/uli-community/assets/js/cluster_bubble_chart.js
@@ -1,0 +1,154 @@
+import * as d3 from "d3";
+
+// Circle-packing layout: pack() computes exact, non-overlapping positions in
+// one pass (no physics to tune), so clusters and their words nest naturally.
+//
+// Labels are counter-scaled against the zoom transform (via their own
+// `scale(1/k)`) so their on-screen pixel size stays constant instead of
+// growing/shrinking with the circles. Whether a word is shown is decided
+// each zoom tick by comparing its (constant) pixel width against its
+// circle's current on-screen diameter — so words hidden at the overview
+// reliably become readable once you've zoomed in far enough to fit them,
+// instead of the fit ratio being invariant to zoom (the old bug).
+const LEAF_FONT_PX = 11;
+const CLUSTER_FONT_PX = 12;
+
+export function drawClusterPack() {
+  const container = document.querySelector("#cluster-bubbles");
+  if (!container || !container.dataset.clusters) return;
+
+  const clusters = JSON.parse(container.dataset.clusters);
+  if (!clusters || clusters.length === 0) return;
+
+  d3.select("#cluster-bubbles").select("svg").remove();
+
+  const width = container.clientWidth || 900;
+  const height = container.clientHeight || 700;
+
+  const data = {
+    name: "root",
+    children: clusters.map(c => ({
+      name: c.cluster,
+      children: c.words.map(word => ({ name: word, value: 1 })),
+    })),
+  };
+
+  const root = d3.hierarchy(data).sum(d => d.value);
+  d3.pack()
+    .size([width, height])
+    .padding(d => (d.depth === 0 ? 20 : 4))(root);
+
+  const color = d3.scaleOrdinal(d3.schemeTableau10).domain(clusters.map(c => c.cluster));
+
+  const svg = d3.select("#cluster-bubbles")
+    .append("svg")
+    .attr("width", "100%")
+    .attr("height", "100%")
+    .attr("viewBox", `0 0 ${width} ${height}`)
+    .attr("preserveAspectRatio", "xMidYMid meet")
+    .style("cursor", "grab");
+
+  const g = svg.append("g");
+
+  const clusterG = g.selectAll("g.cluster")
+    .data(root.children || [])
+    .enter()
+    .append("g")
+    .attr("class", "cluster")
+    .attr("transform", d => `translate(${d.x}, ${d.y})`);
+
+  clusterG.append("circle")
+    .attr("r", d => d.r)
+    .attr("fill", d => color(d.data.name))
+    .attr("fill-opacity", 0.06)
+    .attr("stroke", d => color(d.data.name))
+    .attr("stroke-width", 1.5);
+
+  // Centered inside the cluster's own circle, small and dim, so it reads as
+  // context rather than competing with the word bubbles.
+  const clusterLabel = clusterG.append("text")
+    .attr("text-anchor", "middle")
+    .attr("dy", "0.32em")
+    .style("font-size", `${CLUSTER_FONT_PX}px`)
+    .style("font-weight", "700")
+    .style("fill", d => color(d.data.name))
+    .style("opacity", 0.4)
+    .style("pointer-events", "none")
+    .text(d => (d.data.name === "unclustered" ? "Unclustered" : `#${d.data.name}`));
+
+  const leaf = g.selectAll("g.leaf")
+    .data(root.leaves())
+    .enter()
+    .append("g")
+    .attr("class", "leaf")
+    .attr("transform", d => `translate(${d.x}, ${d.y})`);
+
+  leaf.append("circle")
+    .attr("r", d => d.r)
+    .attr("fill", d => color(d.parent.data.name))
+    .attr("fill-opacity", 0.85)
+    .attr("stroke", "white")
+    .attr("stroke-width", 1);
+
+  leaf.append("title").text(d => `${d.data.name} (cluster ${d.parent.data.name})`);
+
+  const leafLabel = leaf.append("text")
+    .attr("text-anchor", "middle")
+    .style("font-size", `${LEAF_FONT_PX}px`)
+    .style("fill", "#1f2937")
+    .style("pointer-events", "none");
+
+  // Multi-word labels wrap one word per line, centered vertically, instead
+  // of being hidden just because the full phrase is too wide for one line.
+  // Measure the widest line's constant pixel width once; used every zoom
+  // tick to decide whether it currently fits inside its on-screen circle.
+  const LINE_HEIGHT_EM = 1.05;
+  leafLabel.each(function (d) {
+    const words = d.data.name.split(/\s+/).filter(Boolean);
+    const textEl = d3.select(this);
+    const startDy = -((words.length - 1) / 2) * LINE_HEIGHT_EM;
+
+    words.forEach((word, i) => {
+      textEl.append("tspan")
+        .attr("x", 0)
+        .attr("dy", i === 0 ? `${startDy}em` : `${LINE_HEIGHT_EM}em`)
+        .text(word);
+    });
+
+    d.textWidthPx = d3.max(this.querySelectorAll("tspan"), tspan => tspan.getComputedTextLength());
+    d.textHeightPx = words.length * LINE_HEIGHT_EM * LEAF_FONT_PX;
+  });
+
+  // A label is allowed to overflow its own bubble a bit rather than being
+  // hidden outright — otherwise a long word in a small bubble can end up
+  // with nothing shown at any zoom level, which reads as broken rather than
+  // as "zoom in more". 1.6 means up to ~30% overflow past each edge.
+  const OVERFLOW_ALLOWANCE = 1.6;
+
+  const zoom = d3.zoom()
+    .scaleExtent([0.5, 24])
+    .on("zoom", event => {
+      const { transform } = event;
+      g.attr("transform", transform);
+      const k = transform.k;
+      const inv = 1 / k;
+
+      clusterLabel.attr("transform", `scale(${inv})`);
+
+      leafLabel
+        .attr("transform", `scale(${inv})`)
+        .style("display", d => {
+          const diameter = 2 * d.r * k * OVERFLOW_ALLOWANCE;
+          return d.textWidthPx <= diameter && d.textHeightPx <= diameter ? null : "none";
+        });
+    })
+    .on("start", () => svg.style("cursor", "grabbing"))
+    .on("end", () => svg.style("cursor", "grab"));
+
+  svg.call(zoom).call(zoom.transform, d3.zoomIdentity);
+
+  const resetButton = document.getElementById("cluster-bubbles-reset");
+  if (resetButton) {
+    resetButton.onclick = () => svg.transition().duration(400).call(zoom.transform, d3.zoomIdentity);
+  }
+}

--- a/uli-community/assets/js/hooks/cluster_bubble_chart_hook.js
+++ b/uli-community/assets/js/hooks/cluster_bubble_chart_hook.js
@@ -1,0 +1,10 @@
+import { drawClusterPack } from "../cluster_bubble_chart";
+
+export const ClusterBubbleChartHook = {
+  mounted() {
+    drawClusterPack();
+  },
+  updated() {
+    drawClusterPack();
+  }
+};

--- a/uli-community/config/dev.exs
+++ b/uli-community/config/dev.exs
@@ -90,4 +90,4 @@ config :uli_community, :python,
   python_path: Path.join([File.cwd!(), "lib", "python"])
 
 # text vec genserver for dev setup
-config :uli_community, :enable_text_vec_rep_vyakyarth, true
+config :uli_community, :enable_text_vec_rep_vyakyarth, false

--- a/uli-community/lib/scripts/extract_crowdsourced_slur_embedding.ex
+++ b/uli-community/lib/scripts/extract_crowdsourced_slur_embedding.ex
@@ -11,11 +11,16 @@ defmodule Scripts.ExtractCrowdsourcedSlurEmbedding do
   A word is considered unprocessed if it doesn't have a corresponding embedding i.e. an entry in text_vec_store_vyakyarth table
   """
   def enqueue_unprocessed_texts_batch do
+    # labels that already have an embedding, from any crowdsourced_slur row
+    embedded_labels_query =
+      from v in TextVecStoreVyakyarth,
+        join: s in CrowdsourcedSlur,
+        on: v.crowdsourced_slur_id == s.id,
+        select: fragment("LOWER(TRIM(?))", s.label)
+
     unprocessed_slurs_query =
       from s in CrowdsourcedSlur,
-        left_join: v in TextVecStoreVyakyarth,
-        on: v.crowdsourced_slur_id == s.id,
-        where: is_nil(v.id),
+        where: fragment("LOWER(TRIM(?))", s.label) not in subquery(embedded_labels_query),
         group_by: fragment("LOWER(TRIM(?))", s.label),
         select: %{
           id: min(s.id),

--- a/uli-community/lib/uli_community/media_processing/cluster_viz.ex
+++ b/uli-community/lib/uli_community/media_processing/cluster_viz.ex
@@ -1,0 +1,26 @@
+defmodule UliCommunity.MediaProcessing.ClusterViz do
+  import Ecto.Query
+  alias UliCommunity.Repo
+  alias UliCommunity.MediaProcessing.Store.TextVecStoreVyakyarth
+  alias UliCommunity.UserContribution.CrowdsourcedSlur
+
+  # Returns clusters as a list of %{cluster: cluster_id, words: [label, ...]},
+  # largest clusters first. Vectors without a cluster assignment yet are
+  # grouped together under "unclustered" and sorted last.
+  def list_clusters do
+    query =
+      from v in TextVecStoreVyakyarth,
+        join: s in CrowdsourcedSlur,
+        on: v.crowdsourced_slur_id == s.id,
+        select: %{cluster: v.cluster, label: s.label}
+
+    Repo.all(query)
+    |> Enum.group_by(fn %{cluster: cluster} -> cluster || "unclustered" end, & &1.label)
+    |> Enum.map(fn {cluster, labels} ->
+      %{cluster: cluster, words: labels |> Enum.uniq() |> Enum.sort()}
+    end)
+    |> Enum.sort_by(fn %{cluster: cluster, words: words} ->
+      {cluster == "unclustered", -length(words)}
+    end)
+  end
+end

--- a/uli-community/lib/uli_community/media_processing/vector_search.ex
+++ b/uli-community/lib/uli_community/media_processing/vector_search.ex
@@ -8,16 +8,21 @@ defmodule UliCommunity.MediaProcessing.VectorSearch do
   # Returns top N most similar slurs to the query string
   def search_similar_slurs(query, top_n \\ 10) do
     with {:ok, embedding} <- TextVecRepVyakyarth.get_embedding(query) do
-      # Rank base entries (distinct, normalized) by similarity
+      # Rank base entries by similarity, collapsing duplicate embeddings
+      # that can accumulate for the same normalized label over time
       ranked_labels =
         from v in TextVecStoreVyakyarth,
           join: s in CrowdsourcedSlur,
           on: v.crowdsourced_slur_id == s.id,
+          # bucket rows that share a label instead of one row per embedding
+          group_by: fragment("LOWER(TRIM(?))", s.label),
           select: %{
             normalized_label: fragment("LOWER(TRIM(?))", s.label),
-            distance: fragment("? <=> ?", v.embedding, ^embedding)
+            # each bucket can hold >1 distance, keep the closest one
+            distance: min(fragment("? <=> ?", v.embedding, ^embedding))
           },
-          order_by: fragment("? <=> ?", v.embedding, ^embedding),
+          # must sort by the same aggregate used above, not the raw column
+          order_by: min(fragment("? <=> ?", v.embedding, ^embedding)),
           limit: ^top_n
 
       # Fetch all variants, ordered by the rank of their label

--- a/uli-community/lib/uli_community/media_processing/vector_search.ex
+++ b/uli-community/lib/uli_community/media_processing/vector_search.ex
@@ -13,7 +13,7 @@ defmodule UliCommunity.MediaProcessing.VectorSearch do
         from v in TextVecStoreVyakyarth,
           join: s in CrowdsourcedSlur,
           on: v.crowdsourced_slur_id == s.id,
-          order_by: fragment("? <-> ?", v.embedding, ^embedding),
+          order_by: fragment("? <=> ?", v.embedding, ^embedding),
           limit: ^top_n,
           select: fragment("LOWER(TRIM(?))", s.label)
 
@@ -25,7 +25,13 @@ defmodule UliCommunity.MediaProcessing.VectorSearch do
           where: fragment("LOWER(TRIM(?))", s.label) in ^normalized_labels,
           select: s
 
-      Repo.all(all_variants_query)
+      results = Repo.all(all_variants_query)
+      normalized_query = query |> String.trim() |> String.downcase()
+
+      # Exact label matches should rank above purely semantic matches
+      Enum.sort_by(results, fn slur ->
+        if String.downcase(String.trim(slur.label)) == normalized_query, do: 0, else: 1
+      end)
     end
   end
 end

--- a/uli-community/lib/uli_community/media_processing/vector_search.ex
+++ b/uli-community/lib/uli_community/media_processing/vector_search.ex
@@ -8,30 +8,27 @@ defmodule UliCommunity.MediaProcessing.VectorSearch do
   # Returns top N most similar slurs to the query string
   def search_similar_slurs(query, top_n \\ 10) do
     with {:ok, embedding} <- TextVecRepVyakyarth.get_embedding(query) do
-      # Fetch top N similar base entries (distinct, normalized)
-      base_query =
+      # Rank base entries (distinct, normalized) by similarity
+      ranked_labels =
         from v in TextVecStoreVyakyarth,
           join: s in CrowdsourcedSlur,
           on: v.crowdsourced_slur_id == s.id,
+          select: %{
+            normalized_label: fragment("LOWER(TRIM(?))", s.label),
+            distance: fragment("? <=> ?", v.embedding, ^embedding)
+          },
           order_by: fragment("? <=> ?", v.embedding, ^embedding),
-          limit: ^top_n,
-          select: fragment("LOWER(TRIM(?))", s.label)
+          limit: ^top_n
 
-      normalized_labels = Repo.all(base_query)
-
-      # Fetch all variants from CrowdsourcedSlur
+      # Fetch all variants, ordered by the rank of their label
       all_variants_query =
         from s in CrowdsourcedSlur,
-          where: fragment("LOWER(TRIM(?))", s.label) in ^normalized_labels,
+          join: r in subquery(ranked_labels),
+          on: fragment("LOWER(TRIM(?))", s.label) == r.normalized_label,
+          order_by: r.distance,
           select: s
 
-      results = Repo.all(all_variants_query)
-      normalized_query = query |> String.trim() |> String.downcase()
-
-      # Exact label matches should rank above purely semantic matches
-      Enum.sort_by(results, fn slur ->
-        if String.downcase(String.trim(slur.label)) == normalized_query, do: 0, else: 1
-      end)
+      Repo.all(all_variants_query)
     end
   end
 end

--- a/uli-community/lib/uli_community_web/components/layouts/root.html.heex
+++ b/uli-community/lib/uli_community_web/components/layouts/root.html.heex
@@ -7,6 +7,12 @@
     <.live_title>
       <%= assigns[:page_title] || "Uli Community" %>
     </.live_title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+Devanagari:wght@400;500;600;700&family=Noto+Sans+Bengali:wght@400;500;600;700&family=Noto+Sans+Gujarati:wght@400;500;600;700&family=Noto+Sans+Gurmukhi:wght@400;500;600;700&family=Noto+Sans+Kannada:wght@400;500;600;700&family=Noto+Sans+Malayalam:wght@400;500;600;700&family=Noto+Sans+Oriya:wght@400;500;600;700&family=Noto+Sans+Tamil:wght@400;500;600;700&family=Noto+Sans+Telugu:wght@400;500;600;700&family=Noto+Sans+Meetei+Mayek&family=Noto+Sans+Ol+Chiki&family=Noto+Sans+Arabic:wght@400;500;600;700&display=swap"
+    />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
@@ -86,6 +92,26 @@
         </div>
       </li>
     </ul>
+    <%= if @current_user do %>
+      <ul class="relative z-10 flex items-center justify-end gap-4 px-4 sm:px-6 lg:px-8 border-t border-zinc-200 py-2">
+        <li>
+          <.link
+            href={~p"/crowdsource-contributions"}
+            class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
+          >
+            <%= gettext("Crowdsource Contributions") %>
+          </.link>
+        </li>
+        <li>
+          <.link
+            href={~p"/cluster-viz"}
+            class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
+          >
+            <%= gettext("Cluster Visualization") %>
+          </.link>
+        </li>
+      </ul>
+    <% end %>
     <%= @inner_content %>
   </body>
 </html>

--- a/uli-community/lib/uli_community_web/live/cluster_viz_live.ex
+++ b/uli-community/lib/uli_community_web/live/cluster_viz_live.ex
@@ -1,0 +1,24 @@
+defmodule UliCommunityWeb.ClusterVizLive do
+  use UliCommunityWeb, :live_view
+
+  alias UliCommunity.MediaProcessing.ClusterViz
+
+  @impl true
+  def mount(_params, _session, socket) do
+    clusters = ClusterViz.list_clusters()
+    word_count = Enum.reduce(clusters, 0, fn c, acc -> acc + length(c.words) end)
+
+    {:ok,
+     assign(socket,
+       clusters: clusters,
+       cluster_count: length(clusters),
+       word_count: word_count,
+       view: "bubbles"
+     )}
+  end
+
+  @impl true
+  def handle_event("set-view", %{"view" => view}, socket) do
+    {:noreply, assign(socket, view: view)}
+  end
+end

--- a/uli-community/lib/uli_community_web/live/cluster_viz_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/cluster_viz_live.html.heex
@@ -1,0 +1,85 @@
+<div class="max-w-7xl mx-auto p-4">
+  <div class="mb-6 flex items-start justify-between gap-4 flex-wrap">
+    <div>
+      <h1 class="text-2xl font-bold text-zinc-900">Crowdsource Contributions Cluster Explorer</h1>
+      <p class="text-sm text-zinc-500 mt-1">
+        <%= @word_count %> words across <%= @cluster_count %> clusters
+      </p>
+    </div>
+
+    <div class="flex gap-2">
+      <button
+        phx-click="set-view"
+        phx-value-view="bubbles"
+        class={[
+          "px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors cursor-pointer",
+          if(@view == "bubbles",
+            do: "bg-zinc-900 text-white border-zinc-900",
+            else: "bg-white text-zinc-700 border-zinc-300 hover:bg-zinc-50"
+          )
+        ]}
+      >
+        Bubble Clusters
+      </button>
+      <button
+        phx-click="set-view"
+        phx-value-view="list"
+        class={[
+          "px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors cursor-pointer",
+          if(@view == "list",
+            do: "bg-zinc-900 text-white border-zinc-900",
+            else: "bg-white text-zinc-700 border-zinc-300 hover:bg-zinc-50"
+          )
+        ]}
+      >
+        Grouped List
+      </button>
+    </div>
+  </div>
+
+  <%= if @cluster_count == 0 do %>
+    <div class="border border-zinc-200 rounded-lg p-8 text-center text-zinc-500">
+      No clustered vectors found yet. Run <code class="bg-zinc-100 px-1 rounded">Scripts.ClusterTextVecStore.run</code> first.
+    </div>
+  <% else %>
+    <%= if @view == "bubbles" do %>
+      <div class="flex items-center justify-between mb-2">
+        <p class="text-xs text-zinc-400">Scroll to zoom, drag to pan.</p>
+        <button
+          id="cluster-bubbles-reset"
+          type="button"
+          class="px-2.5 py-1 rounded-md text-xs font-medium border border-zinc-300 text-zinc-600 cursor-pointer hover:bg-zinc-50"
+        >
+          Reset view
+        </button>
+      </div>
+      <div
+        id="cluster-bubbles"
+        phx-hook="ClusterBubbleChartHook"
+        data-clusters={Jason.encode!(@clusters)}
+        class="w-full h-[75vh] border border-zinc-200 rounded-xl bg-white"
+      >
+      </div>
+    <% else %>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <%= for cluster <- @clusters do %>
+          <div class="border border-zinc-200 rounded-xl p-4 bg-white">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="font-semibold text-zinc-800">
+                <%= if cluster.cluster == "unclustered", do: "Unclustered", else: "Cluster #{cluster.cluster}" %>
+              </h2>
+              <span class="text-xs text-zinc-400"><%= length(cluster.words) %> words</span>
+            </div>
+            <div class="flex flex-wrap gap-1.5">
+              <%= for word <- cluster.words do %>
+                <span class="px-2 py-1 bg-zinc-100 text-zinc-700 rounded-full text-xs">
+                  <%= word %>
+                </span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/uli-community/lib/uli_community_web/router.ex
+++ b/uli-community/lib/uli_community_web/router.ex
@@ -163,6 +163,7 @@ defmodule UliCommunityWeb.Router do
       live "/admin/import-slurs", ImportSlursCsvLive, :index
       live "/gentoken", TokenGeneratorLive, :index
       live "/crowdsource-contributions", CrowdsourceContributionsLive, :index
+      live "/cluster-viz", ClusterVizLive, :index
       live "/plugin-metadata/:slur_label", PluginMetadataSlurLive, :index
       live "/dashboard", DashboardLive
 


### PR DESCRIPTION
## Summary
- Add a cluster visualization page (`/cluster-viz`) for crowdsourced slur clusters, with a D3 circle-packing bubble chart (zoom/pan) and a grouped list view toggle.
- Add Noto Sans fallback fonts so crowdsourced labels across Indic scripts render correctly instead of showing boxes.

### Advanced Search Ranking Fix
The original implementation had two ranking bugs. First, results were ordered using Euclidean distance (<->), while the embedding model (Vyakyarth) is explicitly designed and documented to be compared using cosine similarity (<=>). Ref: https://huggingface.co/krutrim-ai-labs/Vyakyarth/blob/main/config_sentence_transformers.json. In practice, this made no visible difference to the observed rankings.

Second, and more significantly, the correct similarity ranking computed by the initial query was silently discarded. The code first fetched the closest matching labels in proper distance order, but then ran a second, separate query to expand each label into all of its database variants. That second query had no ORDER BY, so Postgres was free to return rows in arbitrary internal order. The net effect was that even though the closest match was correctly identified internally, the final list shown to the user often did not reflect that ranking at all. For example, searching "crazy" could surface "lunatic" or "promiscuous" ahead of the literal word "crazy".

The fix collapses this into a single query. The ranked candidate labels are computed as a subquery using cosine distance and joined directly against all matching slur variants, with the outer query ordered by that same distance value. This preserves the correct similarity ranking end to end instead of computing it and then throwing it away.

A related issue was also addressed: the same normalized label could end up with more than one embedding row in the vector store over time (see coderabbit's comment: https://github.com/tattle-made/Uli/pull/974#discussion_r3821909212), which meant it could consume multiple top_n slots in the ranked candidate list and cause its variants to appear more than once in the final results. The ranked-candidates subquery now groups by normalized label and keeps only the closest embedding per label before the limit is applied, so each label occupies exactly one slot regardless of how many redundant embeddings exist for it.

### Changes in the Embedding Creation Script
`Scripts.ExtractCrowdsourcedSlurEmbedding.enqueue_unprocessed_texts_batch/0` decided whether a slur needed an embedding by checking if that specific database row already had one, rather than checking if that label already had one anywhere. This meant that whenever a new crowdsourced_slurs row was added with a label that had already been embedded under a different row's id, the script would treat it as unprocessed and enqueue a redundant embedding for the same label. Since this script is expected to run repeatedly as new slurs get contributed over time, this would reliably produce duplicate embeddings for the same label. The fix changes the "already processed" check to look up whether the label itself has any existing embedding, so re-running the script no longer creates duplicate embeddings for labels it has already processed.

This is safe because `search_similar_slurs` in `vector_search.ex` matches results by label text, not by row id: `all_variants_query` joins every crowdsourced_slurs row to the ranked candidates on normalized label, not on `crowdsourced_slur_id`. So a row without its own embedding still appears in search results as long as at least one other row sharing its normalized label has one, it simply rides along on that shared embedding rather than needing a redundant one of its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated Cluster Visualization page with bubble-chart and grouped-list views.
  * Added interactive zooming, labels, tooltips, and a reset control for cluster bubbles.
  * Added navigation links for Crowdsource Contributions and Cluster Visualization.
  * Improved font support for Indic and Arabic scripts.

* **Bug Fixes**
  * Improved semantic search ordering, prioritizing exact label matches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->